### PR TITLE
Stop using deprecated React methods

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal-bootstrap",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Modal component for ReactJS with Bootstrap style.",
   "main": "dist/react-modal-bootstrap.js",
   "keywords": [

--- a/error.txt
+++ b/error.txt
@@ -1,0 +1,4 @@
+console.warn node_modules/react/lib/lowPriorityWarning.js:40
+      Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class
+    console.warn node_modules/react/lib/lowPriorityWarning.js:40
+      Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs

--- a/error.txt
+++ b/error.txt
@@ -1,4 +1,0 @@
-console.warn node_modules/react/lib/lowPriorityWarning.js:40
-      Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class
-    console.warn node_modules/react/lib/lowPriorityWarning.js:40
-      Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal-bootstrap",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Modal component for ReactJS with Bootstrap style.",
   "main": "lib/index.js",
   "scripts": {
@@ -24,6 +24,7 @@
   "dependencies": {
     "classnames": "^2.1.1",
     "lodash.assign": "^4.0.7",
+    "prop-types": "^15.5.10",
     "radium": "0.18.0"
   },
   "devDependencies": {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Radium from 'radium';
 import assign from 'lodash.assign';
@@ -13,17 +14,17 @@ const findParentNode = (parentClass, child) => {
 };
 
 @Radium
-class Modal extends React.Component {
+class Modal extends Component {
   static propTypes = {
-    className: React.PropTypes.string,
-    isOpen: React.PropTypes.bool.isRequired,
-    backdrop: React.PropTypes.bool,
-    keyboard: React.PropTypes.bool,
-    size: React.PropTypes.oneOf(['modal-lg', 'modal-sm', '']),
-    onRequestHide: React.PropTypes.func,
-    backdropStyles: React.PropTypes.object,
-    dialogStyles: React.PropTypes.object,
-    children: React.PropTypes.node.isRequired
+    className: PropTypes.string,
+    isOpen: PropTypes.bool.isRequired,
+    backdrop: PropTypes.bool,
+    keyboard: PropTypes.bool,
+    size: PropTypes.oneOf(['modal-lg', 'modal-sm', '']),
+    onRequestHide: PropTypes.func,
+    backdropStyles: PropTypes.object,
+    dialogStyles: PropTypes.object,
+    children: PropTypes.node.isRequired
   };
 
   static defaultProps = {

--- a/src/ModalBody.js
+++ b/src/ModalBody.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
-class ModalBody extends React.Component {
+class ModalBody extends Component {
   static propTypes = {
-    children: React.PropTypes.node
+    children: PropTypes.node
   };
 
   render() {

--- a/src/ModalClose.js
+++ b/src/ModalClose.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
-class ModalClose extends React.Component {
+class ModalClose extends Component {
   static propTypes = {
-    onClick: React.PropTypes.func
+    onClick: PropTypes.func
   };
 
   static defaultProps = {

--- a/src/ModalFooter.js
+++ b/src/ModalFooter.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
-class ModalFooter extends React.Component {
+class ModalFooter extends Component {
   static propTypes = {
-    children: React.PropTypes.node
+    children: PropTypes.node
   };
 
   render() {

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
-class ModalHeader extends React.Component {
+class ModalHeader extends Component {
   static propTypes = {
-    children: React.PropTypes.node
+    children: PropTypes.node
   };
 
   render() {

--- a/src/ModalTitle.js
+++ b/src/ModalTitle.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
-class ModalTitle extends React.Component {
+class ModalTitle extends Component {
   static propTypes = {
-    children: React.PropTypes.node
+    children: PropTypes.node
   };
 
   render() {


### PR DESCRIPTION
This PR makes small changes to the code to stop using deprecated React methods, namely to stop accessing Component and PropTypes underneath the React object.

This solves issue #13 .

I've also bumped the version.